### PR TITLE
Fix duplicates and typo in license lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,6 @@
 "4311154644": "https://drive.google.com/file/d/1iHIz42HtqFX_mt3hCBSpooFSmX2v_MVp/view?usp=sharing",
 "4511014640": "https://drive.google.com/file/d/13hVmBqr7Bjjm8C4T5g7PsHjNe74BiiyS/view?usp=sharing",
 "6311309613": "https://drive.google.com/file/d/1wWmwxAt8IfyJfdPmdnoI6fXiOHuhgrV2/view?usp=sharing",
-"6311309613": "https://drive.google.com/file/d/1HhK3AmD1f92KIvOol0pRyQ5bcIUdJ-Qg/view?usp=sharing",
 "6611338954": "https://drive.google.com/file/d/1zUuwDVigVp9sPwxGV65WbiTLSV90cuGL/view?usp=sharing",
 "4611097356": "https://drive.google.com/file/d/1S7Ey_Yaaa8C5HrlV1211dqPw2333Fz8Q/view?usp=sharing",
 "5411063823": "https://drive.google.com/file/d/1Q791eDgKgUcMWZzcDB9DHvX8kooCG_Pm/view?usp=sharing",
@@ -93,7 +92,6 @@
 "6311282000": "https://drive.google.com/file/d/1qsWFnkjIeRzlsPCSaeRODHFS7DyZrvl7/view?usp=sharing",
 "6511326793": "https://drive.google.com/file/d/1RWJjl9AzSRcaZRs8Rd38C9sDy9rYdctG/view?usp=sharing",
 "5911267611": "https://drive.google.com/file/d/1G9Y-hgTfHWajz1h-qlD9YMjmdQBUziKn/view?usp=sharing",
-"5411063823": "https://drive.google.com/file/d/1jQhcFWyABse-JXoRKwO3W4eektARvCwD/view?usp=sharing",
 "5011200796": "https://drive.google.com/file/d/1dsQdu7eu_jZ7t2ddcksCux9YXk3KJxqE/view?usp=sharing",
 "6311303877": "https://drive.google.com/file/d/1u0PfxBOy4rmVpTid_tA8JxzHAQh6WwCx/view?usp=sharing",
 "4711185185": "https://drive.google.com/file/d/1UXQMOnVzy7RCEIFWjUv_OGiirAKUcW6n/view?usp=sharing",
@@ -225,8 +223,7 @@
       if (licenseData[input]) {
         resultDiv.innerHTML = `<p>✅ ยินดีด้วยครับ! <a href="${licenseData[input]}" target="_blank">สามารถดูใบประกาศนียบัตร และ ดาวน์โหลดได้ที่นี่!!</a></p>`;
       } else {
-        resultDiv.innerHTML = `<p style="color:red;">❌ ไม่พบใบประกาศนียบัตรของท่าน อาจจะเกิดจากเลขใบประกอบวิชาชีพของท่านไม่ได้กรอก หรือ กรอกไม่ตรง ตอนสมัคร  <br> กรุณาติดต่อกรุณาติดต่อ (คุุณณัฐฐิญา จ่าราช)
- โทร. 056 000111 ต่อ ฝ่ายการพยาบาล เพื่อรับใบประกาศนียบัตรครับ</p>`;
+        resultDiv.innerHTML = `<p style="color:red;">❌ ไม่พบใบประกาศนียบัตรของท่าน อาจจะเกิดจากเลขใบประกอบวิชาชีพของท่านไม่ได้กรอก หรือ กรอกไม่ตรง ตอนสมัคร  <br> กรุณาติดต่อ (คุณณัฐฐิญา จ่าราช) โทร. 056 000111 ต่อ ฝ่ายการพยาบาล เพื่อรับใบประกาศนียบัตรครับ</p>`;
       }
     }
   </script>


### PR DESCRIPTION
## Summary
- remove duplicate license entries
- fix repeated contact text typo in error message

## Testing
- `grep -o '"[0-9]\{10\}"' index.html | sort | uniq -d`


------
https://chatgpt.com/codex/tasks/task_e_68663fe78508832b881a526309fe778d